### PR TITLE
Document virtual input pin loading from extras

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,10 +1,16 @@
 This is an example with 2 ams units that are hooked up to indivdual tool heads. This is for use with AFC_klipper_addon
 
-Put auto_ams_update.py and virtual_input_pin.py in klipper/klippy/extras
+Put auto_ams_update.py and virtual_input_pin.py in klipper/klippy/extras. The
+`virtual_input_pin` module registers its own `virtual_pin` chip when it is
+loaded, so Klipper's core `pins.py` does not need to be modified. Ensure at
+least one `[virtual_input_pin ...]` section (or `auto_ams_update`) appears
+before any module that uses `virtual_pin:` pins.
 
-AFC_AMS1.cfg and AFC_AMS2.cfg are example AFC configs that go in printer_data/config/AFC.
+AFC_AMS1.cfg and AFC_AMS2.cfg are example AFC configs that go in
+printer_data/config/AFC.
 
-Add [virtual_input_pin enable] in your cfg, or create at least one virtual pin to enable the module
+Add `[virtual_input_pin enable]` in your cfg, or create at least one virtual
+pin to enable the module.
 
 
 ## AMS virtual pins
@@ -66,3 +72,4 @@ Use these pins anywhere an endstop pin is accepted by referencing
 ```
 SET_VIRTUAL_PIN PIN=my_pin VALUE=1
 QUERY_VIRTUAL_PIN PIN=my_pin
+```


### PR DESCRIPTION
## Summary
- clarify that the `virtual_input_pin` module can be placed in `klipper/klippy/extras` without modifying `pins.py`
- close an unclosed code block in the README

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68951ba4a748832692aefb774e1db9d1