### PR TITLE
Add edge detection and non-synchronized AMS pin updates

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,8 @@ virtual pins for each configured AMS using the naming pattern
 [auto_ams_update]
 oams1: oams1
 oams2: oams2
-interval: 1
+# interval defaults to 1 second; uncomment to override
+#interval: 1
 #pins: ams1lane0pl, ams1lane1pl, ams1lane2pl, ams1lane3pl, ams2lane0pl, ams2lane1pl, ams2lane2pl, ams2lane3pl, ams1hub0, ams1hub1, ams1hub2, ams1hub3, ams2hub0, ams2hub1, ams2hub2, ams2hub3
 ```
 


### PR DESCRIPTION
## Summary
- avoid duplicate virtual pin writes by tracking last values
- set default update interval to 1 s
- send SET_VIRTUAL_PIN commands with SYNCHRONIZED=0 to avoid MCU scheduling issues

## Testing
- `python -m py_compile auto_ams_update.py virtual_input_pin.py`


------
https://chatgpt.com/codex/tasks/task_e_689e2a8b1bb88326889ea8bc420a5d1e