### PR TITLE
Install auto AMS update in Klipper extras

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -20,4 +20,15 @@ if ! grep -q "klippy/extras/virtual_input_pin.py" "${KLIPPER_DIR}/.git/info/excl
     echo "klippy/extras/virtual_input_pin.py" >> "${KLIPPER_DIR}/.git/info/exclude"
 fi
 
+echo "virtual_input_pin: linking klippy to auto_ams_update.py."
+
+if [ -e "${KLIPPER_DIR}/klippy/extras/auto_ams_update.py" ]; then
+    rm "${KLIPPER_DIR}/klippy/extras/auto_ams_update.py"
+fi
+ln -s "${VIRTUAL_INPUT_PIN_DIR}/auto_ams_update.py" "${KLIPPER_DIR}/klippy/extras/auto_ams_update.py"
+
+if ! grep -q "klippy/extras/auto_ams_update.py" "${KLIPPER_DIR}/.git/info/exclude"; then
+    echo "klippy/extras/auto_ams_update.py" >> "${KLIPPER_DIR}/.git/info/exclude"
+fi
+
 echo "virtual_input_pin: installation successful."


### PR DESCRIPTION
## Summary
- Link `auto_ams_update.py` into Klipper's extras directory during install
- Add the new module to Klipper's git exclude list

## Testing
- `bash -n install.sh`
- `shellcheck install.sh` (SC2164 warning)
- `./install.sh` (fails: virtual_input_pin: klipper doesn't exist)


------
https://chatgpt.com/codex/tasks/task_e_68a946b634e083269ca5fb0b57fa35a5