### PR TITLE
Integrate OpenAMS lane and hub state updates

### DIFF
--- a/AFC-Klipper-Add-On-direct_update/extras/AFC_hub.py
+++ b/AFC-Klipper-Add-On-direct_update/extras/AFC_hub.py
@@ -49,15 +49,15 @@ class afc_hub:
         self.config_unload_bowden_length = self.afc_unload_bowden_length
         self.enable_sensors_in_gui  = config.getboolean("enable_sensors_in_gui", self.afc.enable_sensors_in_gui) # Set to True to show hub sensor switche as filament sensor in mainsail/fluidd gui, overrides value set in AFC.cfg
 
-        buttons = self.printer.load_object(config, "buttons")
-        if self.switch_pin is not None:
-            self.state = False
-            buttons.register_buttons([self.switch_pin], self.switch_pin_callback)
+        if not self.afc.openams_enabled:
+            buttons = self.printer.load_object(config, "buttons")
+            if self.switch_pin is not None:
+                self.state = False
+                buttons.register_buttons([self.switch_pin], self.switch_pin_callback)
 
-
-        if self.enable_sensors_in_gui:
-            self.filament_switch_name = "filament_switch_sensor {}_Hub".format(self.name)
-            self.fila = add_filament_switch(self.filament_switch_name, self.switch_pin, self.printer )
+            if self.enable_sensors_in_gui:
+                self.filament_switch_name = "filament_switch_sensor {}_Hub".format(self.name)
+                self.fila = add_filament_switch(self.filament_switch_name, self.switch_pin, self.printer )
 
         # Adding self to AFC hubs
         self.afc.hubs[self.name]=self

--- a/AFC-Klipper-Add-On-direct_update/extras/AFC_lane.py
+++ b/AFC-Klipper-Add-On-direct_update/extras/AFC_lane.py
@@ -136,17 +136,21 @@ class AFCLane:
         self.config_dist_hub = self.dist_hub
 
         # lane triggers
-        buttons = self.printer.load_object(config, "buttons")
         self.prep = config.get('prep', None)                                    # MCU pin for prep trigger
         self.prep_state = False
-        if self.prep is not None:
-            buttons.register_buttons([self.prep], self.prep_callback)
-
         self.load = config.get('load', None)                                    # MCU pin load trigger
         self.load_state = False
-        if self.load is not None:
-            buttons.register_buttons([self.load], self.load_callback)
-        else: self.load_state = True
+        if not self.afc.openams_enabled:
+            buttons = self.printer.load_object(config, "buttons")
+            if self.prep is not None:
+                buttons.register_buttons([self.prep], self.prep_callback)
+            if self.load is not None:
+                buttons.register_buttons([self.load], self.load_callback)
+            else:
+                self.load_state = True
+        else:
+            if self.load is None:
+                self.load_state = True
 
         self.espooler = AFC_assist.Espooler(self.name, config)
         self.lane_load_count = None
@@ -166,7 +170,7 @@ class AFCLane:
         # Defaulting to false so that extruder motors to not move until PREP has been called
         self._afc_prep_done = False
 
-        if self.enable_sensors_in_gui:
+        if self.enable_sensors_in_gui and not self.afc.openams_enabled:
             if self.prep is not None and (self.sensor_to_show is None or self.sensor_to_show == 'prep'):
                 self.prep_filament_switch_name = "filament_switch_sensor {}_prep".format(self.name)
                 self.fila_prep = add_filament_switch(self.prep_filament_switch_name, self.prep, self.printer )

--- a/klipper_openams-multiple_fps_oams2/src/oams_manager.py
+++ b/klipper_openams-multiple_fps_oams2/src/oams_manager.py
@@ -17,7 +17,7 @@ MIN_ENCODER_DIFF = 1  # Minimum encoder difference to consider movement
 FILAMENT_PATH_LENGTH_FACTOR = 1.14  # Factor for calculating filament path traversal
 MONITOR_ENCODER_LOADING_SPEED_AFTER = 2.0  # seconds
 # Poll runout and spool state once per second for faster reaction times
-MONITOR_ENCODER_PERIOD = 1.0  # seconds
+MONITOR_ENCODER_PERIOD = 2.0  # seconds
 MONITOR_ENCODER_UNLOADING_SPEED_AFTER = 2.0  # seconds
 
 

--- a/klipper_openams-multiple_fps_oams2/src/oams_manager.py
+++ b/klipper_openams-multiple_fps_oams2/src/oams_manager.py
@@ -16,7 +16,8 @@ ENCODER_SAMPLES = 2  # Number of encoder samples to collect
 MIN_ENCODER_DIFF = 1  # Minimum encoder difference to consider movement
 FILAMENT_PATH_LENGTH_FACTOR = 1.14  # Factor for calculating filament path traversal
 MONITOR_ENCODER_LOADING_SPEED_AFTER = 2.0  # seconds
-MONITOR_ENCODER_PERIOD = 2.0 # seconds
+# Poll runout and spool state once per second for faster reaction times
+MONITOR_ENCODER_PERIOD = 1.0  # seconds
 MONITOR_ENCODER_UNLOADING_SPEED_AFTER = 2.0  # seconds
 
 
@@ -600,11 +601,9 @@ class OAMSManager:
     
     def start_monitors(self):
         self.monitor_timers = []
-        reactor = self.printer.get_reactor()        
+        reactor = self.printer.get_reactor()
         for (fps_name, fps_state) in self.current_state.fps_state.items():
-            self.monitor_timers.append(reactor.register_timer(self._monitor_unload_speed_for_fps(fps_name), reactor.NOW))
-            self.monitor_timers.append(reactor.register_timer(self._monitor_load_speed_for_fps(fps_name), reactor.NOW))
-            
+
             def _reload_callback():
                 for (oam, bay_index) in self.filament_groups[fps_state.current_group].bays:
                     if oam.is_bay_ready(bay_index):
@@ -625,11 +624,19 @@ class OAMSManager:
                 self._pause_printer_message("No spool available for group %s" % fps_state.current_group)
                 self.runout_monitor.paused()
                 return
-            
-            self.runout_monitor = OAMSRunoutMonitor(self.printer, fps_name, self.fpss[fps_name], fps_state, self.oams, _reload_callback, reload_before_toolhead_distance=self.reload_before_toolhead_distance)
+
+            # Register runout monitor first so it gets priority
+            self.runout_monitor = OAMSRunoutMonitor(self.printer, fps_name, self.fpss[fps_name],
+                                                    fps_state, self.oams, _reload_callback,
+                                                    reload_before_toolhead_distance=self.reload_before_toolhead_distance)
             self.monitor_timers.append(self.runout_monitor.timer)
             self.runout_monitor.start()
-            
+
+            # Delay speed monitors slightly to let runout checks run first
+            start_time = reactor.monotonic() + MONITOR_ENCODER_PERIOD
+            self.monitor_timers.append(reactor.register_timer(self._monitor_unload_speed_for_fps(fps_name), start_time))
+            self.monitor_timers.append(reactor.register_timer(self._monitor_load_speed_for_fps(fps_name), start_time))
+
         logging.info("OAMS: All monitors started")
     
     def stop_monitors(self):


### PR DESCRIPTION
## Summary
- add `afc_openams` config block to register OpenAMS object names
- poll OpenAMS for lane and hub sensors and update AFC lanes/hubs
- allow AFCLane and afc_hub to accept OpenAMS-driven states without MCU pins
- prioritize runout monitor and poll once per second for faster spool switching
- retain original `oams_manager` with 2 s monitor interval

## Testing
- `python -m py_compile klipper_openams-multiple_fps_oams2/src/oams_manager.py AFC-Klipper-Add-On-direct_update/extras/AFC.py AFC-Klipper-Add-On-direct_update/extras/AFC_lane.py AFC-Klipper-Add-On-direct_update/extras/AFC_hub.py`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68bc74741bac8326ac723717588704d5