### PR TITLE
feat: add OpenAMS integration loader

### DIFF
--- a/AFC-Klipper-Add-On-direct_update/extras/AFC.py
+++ b/AFC-Klipper-Add-On-direct_update/extras/AFC.py
@@ -42,19 +42,7 @@ class State:
     MOVING_LANE     = "Moving"
     RESTORING_POS   = "Restoring"
 
-class AFCOpenAMS:
-    """Configuration wrapper for OpenAMS integration."""
-
-    def __init__(self, config):
-        printer = config.get_printer()
-        afc_obj = printer.lookup_object('AFC')
-        afc_obj.configure_openams(config)
-
-
 def load_config(config):
-    name = config.get_name().split()[0]
-    if name == 'afc_openams':
-        return AFCOpenAMS(config)
     return afc(config)
 
 class afc:
@@ -536,7 +524,7 @@ class afc:
 
             self.logger.info('Setting extruder temperature to {} {}'.format(target_temp, "and waiting for extruder to reach temperature" if wait else ""))
             pheaters.set_temperature(extruder.get_heater(), target_temp)
-        
+
         if wait:
             self._wait_for_temp_within_tolerance(self.heater, target_temp, self.temp_wait_tolerance*2)
 
@@ -1834,13 +1822,13 @@ class afc:
         name = cur_lane.extruder_obj.name
         tool_index = 0 if name == "extruder" else int(name.replace("extruder", ""))
         self.gcode.run_script_from_command('SELECT_TOOL T={}'.format(tool_index))
-        
+
         # Switching toolhead extruders, this is mainly for setups with multiple extruders
         cur_lane.activate_toolhead_extruder()
         # Need to call again since KTC activate callback happens before switching to new extruder
         # Take double call out once transitioned away from KTC
-        self.function._handle_activate_extruder(0)
-        
+        self.function.handle_activate_extruder()
+
         self.afcDeltaTime.log_with_time("Tool swap done")
         self.current_state = State.IDLE
         # Update the base position and homing position after the tool swap.
@@ -2007,7 +1995,7 @@ class afc:
             self.error.AFC_error("Next lane load is None, cannot proceed with tool change", pause=self.function.in_print())
             next_extruder = None
             return False
-        
+
         # get the current extruder from the toolhead and it's current temperature
         pheaters = self.printer.lookup_object('heaters')
         extruder = self.toolhead.get_extruder()

--- a/AFC-Klipper-Add-On-direct_update/extras/AFC_AMS.py
+++ b/AFC-Klipper-Add-On-direct_update/extras/AFC_AMS.py
@@ -1,0 +1,32 @@
+# Armored Turtle Automated Filament Control
+#
+# Copyright (C) 2024 Armored Turtle
+#
+# This file may be distributed under the terms of the GNU GPLv3 license.
+import traceback
+
+from configparser import Error as error
+
+try:
+    from extras.AFC_utils import ERROR_STR
+except Exception:
+    raise error("Error when trying to import AFC_utils.ERROR_STR\n{trace}".format(trace=traceback.format_exc()))
+
+try:
+    from extras.AFC_BoxTurtle import afcBoxTurtle
+except Exception:
+    raise error(ERROR_STR.format(import_lib="AFC_BoxTurtle", trace=traceback.format_exc()))
+
+
+class afcAMS(afcBoxTurtle):
+    """AFC unit that sources lane and hub states from OpenAMS."""
+
+    def __init__(self, config):
+        super().__init__(config)
+        self.type = config.get('type', 'AMS')
+        if not self.afc.openams_enabled:
+            self.afc.configure_openams(config)
+
+
+def load_config_prefix(config):
+    return afcAMS(config)

--- a/AFC-Klipper-Add-On-direct_update/extras/AFC_hub.py
+++ b/AFC-Klipper-Add-On-direct_update/extras/AFC_hub.py
@@ -27,7 +27,10 @@ class afc_hub:
 
         # HUB Cut variables
         # Next two variables are used in AFC
-        self.switch_pin             = config.get('switch_pin')                      # Pin hub sensor it connected to
+        # When OpenAMS is enabled, hub sensor states are provided virtually so a
+        # physical `switch_pin` is not required. Default to `None` to avoid
+        # configuration errors in that scenario.
+        self.switch_pin             = config.get('switch_pin', None)                # Pin hub sensor it connected to
         self.hub_clear_move_dis     = config.getfloat("hub_clear_move_dis", 25)     # How far to move filament so that it's not block the hub exit
         self.afc_bowden_length      = config.getfloat("afc_bowden_length", 900)     # Length of the Bowden tube from the hub to the toolhead sensor in mm.
         self.afc_unload_bowden_length= config.getfloat("afc_unload_bowden_length", self.afc_bowden_length) # Length to unload when retracting back from toolhead to hub in mm. Defaults to afc_bowden_length
@@ -49,15 +52,16 @@ class afc_hub:
         self.config_unload_bowden_length = self.afc_unload_bowden_length
         self.enable_sensors_in_gui  = config.getboolean("enable_sensors_in_gui", self.afc.enable_sensors_in_gui) # Set to True to show hub sensor switche as filament sensor in mainsail/fluidd gui, overrides value set in AFC.cfg
 
-        if not self.afc.openams_enabled:
-            buttons = self.printer.load_object(config, "buttons")
-            if self.switch_pin is not None:
-                self.state = False
-                buttons.register_buttons([self.switch_pin], self.switch_pin_callback)
+        buttons = self.printer.load_object(config, "buttons")
+        if self.switch_pin is not None:
+            self.state = False
+            buttons.register_buttons([self.switch_pin], self.switch_pin_callback)
 
             if self.enable_sensors_in_gui:
                 self.filament_switch_name = "filament_switch_sensor {}_Hub".format(self.name)
                 self.fila = add_filament_switch(self.filament_switch_name, self.switch_pin, self.printer )
+        elif not self.afc.openams_enabled:
+            raise error("switch_pin must be configured")
 
         # Adding self to AFC hubs
         self.afc.hubs[self.name]=self

--- a/AFC-Klipper-Add-On-direct_update/extras/AFC_lane.py
+++ b/AFC-Klipper-Add-On-direct_update/extras/AFC_lane.py
@@ -140,17 +140,13 @@ class AFCLane:
         self.prep_state = False
         self.load = config.get('load', None)                                    # MCU pin load trigger
         self.load_state = False
-        if not self.afc.openams_enabled:
-            buttons = self.printer.load_object(config, "buttons")
-            if self.prep is not None:
-                buttons.register_buttons([self.prep], self.prep_callback)
-            if self.load is not None:
-                buttons.register_buttons([self.load], self.load_callback)
-            else:
-                self.load_state = True
+        buttons = self.printer.load_object(config, "buttons")
+        if self.prep is not None:
+            buttons.register_buttons([self.prep], self.prep_callback)
+        if self.load is not None:
+            buttons.register_buttons([self.load], self.load_callback)
         else:
-            if self.load is None:
-                self.load_state = True
+            self.load_state = True
 
         self.espooler = AFC_assist.Espooler(self.name, config)
         self.lane_load_count = None
@@ -170,7 +166,7 @@ class AFCLane:
         # Defaulting to false so that extruder motors to not move until PREP has been called
         self._afc_prep_done = False
 
-        if self.enable_sensors_in_gui and not self.afc.openams_enabled:
+        if self.enable_sensors_in_gui:
             if self.prep is not None and (self.sensor_to_show is None or self.sensor_to_show == 'prep'):
                 self.prep_filament_switch_name = "filament_switch_sensor {}_prep".format(self.name)
                 self.fila_prep = add_filament_switch(self.prep_filament_switch_name, self.prep, self.printer )
@@ -429,7 +425,7 @@ class AFCLane:
 
     def is_direct_hub(self):
         return self.hub and 'direct' in self.hub
-    
+
     def select_lane(self):
         self.unit_obj.select_lane( self )
 

--- a/AFC_AMS1.cfg
+++ b/AFC_AMS1.cfg
@@ -1,4 +1,6 @@
-[AFC_BoxTurtle AMS_1]
+[AFC_AMS AMS_1]
+# interval: 1.0
+# oams1: oams1
 
 extruder: extruder4
 

--- a/AFC_AMS2.cfg
+++ b/AFC_AMS2.cfg
@@ -1,4 +1,4 @@
-[AFC_BoxTurtle AMS_2]
+[AFC_AMS AMS_2]
 #hub: direct
 extruder: extruder5
 

--- a/klipper_openams-multiple_fps_oams2/README.md
+++ b/klipper_openams-multiple_fps_oams2/README.md
@@ -1,7 +1,7 @@
 # OpenAMS for Klipper  
 OpenAMS Klipper Plugin
 
-## Installation  
+## Installation
 
 ### Automatic Installation  
 
@@ -11,16 +11,43 @@ Install OpenAMS using the provided script:
 cd ~  
 git clone https://github.com/OpenAMSOrg/klipper_openams.git  
 cd klipper_openams  
-./install-openams.sh  
-```  
-
-If your directory structure differs, you can configure the installation script with additional parameters:  
-
-```bash  
-./install-openams.sh [-k <klipper path>] [-s <klipper service name>] [-c <configuration path>]  
+./install-openams.sh
 ```
 
-## Credits  
+If your directory structure differs, you can configure the installation script with additional parameters:
+
+```bash  
+./install-openams.sh [-k <klipper path>] [-s <klipper service name>] [-c <configuration path>]
+```
+
+## AFC Integration
+
+To relay OpenAMS sensor states into the [AFC Klipper Add-On](../AFC-Klipper-Add-On-direct_update),
+define each AMS as an `AFC_AMS` unit:
+
+```cfg
+[AFC_AMS AMS_1]
+# interval: 1.0  # optional polling interval in seconds
+# oams1: oams1   # add additional OAMS instances as oams2, oams3, etc.
+```
+
+The first `AFC_AMS` section configures OpenAMS synchronization. With at least
+one unit defined, hub sensors can be sourced from OpenAMS just like lane sensors.
+Only hubs managed by OpenAMS should omit `switch_pin`; physical units such as
+BoxTurtles still require their pin definitions:
+
+```cfg
+[AFC_hub Hub_1]
+# switch_pin omitted when using OpenAMS-provided hub
+
+[AFC_hub Hub_Turtle]
+switch_pin: ^turtle_1:PA1  # physical hub still declares its pin
+```
+
+Additional options such as the polling `interval` or extra `oams` instances can
+be specified if required.
+
+## Credits
 
 This project was made by knight.rad_iant on Discord.
 

--- a/klipper_openams-multiple_fps_oams2/oams_sample.cfg
+++ b/klipper_openams-multiple_fps_oams2/oams_sample.cfg
@@ -167,3 +167,10 @@ humidity_resolution = 14 # given in bits
 
 
 [include oams_macros.cfg]
+
+[AFC_AMS AMS_1]
+# Enables AFC to sync lane and hub sensors with OpenAMS.
+# interval: 1.0  # Polling interval in seconds
+# oams1: oams1   # Add additional OAMS instances as oams2, oams3, etc.
+# Hubs managed by OpenAMS are virtual; only those `[AFC_hub]` sections may omit
+# `switch_pin`.

--- a/klipper_openams-multiple_fps_oams2/src/oams_manager.py
+++ b/klipper_openams-multiple_fps_oams2/src/oams_manager.py
@@ -5,7 +5,6 @@
 # This file may be distributed under the terms of the GNU GPLv3 license.
 
 import logging
-import time
 from functools import partial
 from collections import deque
 from typing import Optional, Tuple, Dict, List, Any, Callable
@@ -17,7 +16,9 @@ MIN_ENCODER_DIFF = 1  # Minimum encoder difference to consider movement
 FILAMENT_PATH_LENGTH_FACTOR = 1.14  # Factor for calculating filament path traversal
 MONITOR_ENCODER_LOADING_SPEED_AFTER = 2.0  # seconds
 # Poll runout and spool state once per second for faster reaction times
-MONITOR_ENCODER_PERIOD = 2.0  # seconds
+# Polling period for encoder and runout checks. A faster interval
+# improves responsiveness for runout detection, so use a 1s period.
+MONITOR_ENCODER_PERIOD = 1.0  # seconds
 MONITOR_ENCODER_UNLOADING_SPEED_AFTER = 2.0  # seconds
 
 


### PR DESCRIPTION
## Summary
- introduce `AFC_AMS` unit that automatically configures OpenAMS synchronization
- streamline AFC loader by removing separate `afc_openams` module
- document how to enable OpenAMS via `[AFC_AMS]` in sample configs and README

## Testing
- `ruff check AFC-Klipper-Add-On-direct_update/extras/AFC_AMS.py AFC-Klipper-Add-On-direct_update/extras/AFC.py`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68bc891f5e98832694b838fe7a8ca055