### PR TITLE
feat: add AFC start print dialog components

### DIFF
--- a/src/components/dialogs/StartPrintDialog.vue
+++ b/src/components/dialogs/StartPrintDialog.vue
@@ -1,0 +1,200 @@
+<template>
+  <v-dialog
+    v-model="bool"
+    :max-width="400"
+    content-class="overflow-x-hidden"
+    @click:outside="closeDialog"
+    @keydown.esc="closeDialog"
+  >
+    <v-card>
+      <div
+        v-if="bigThumbnailUrl"
+        class="d-flex align-center justify-center"
+        style="min-height:200px"
+      >
+        <v-img
+          :src="bigThumbnailUrl"
+          :max-width="maxThumbnailWidth"
+          class="d-inline-block"
+          :style="bigThumbnailStyle"
+        />
+      </div>
+
+      <v-card-title class="text-h5">
+        {{ $t('Dialogs.StartPrint.Headline') }}
+      </v-card-title>
+
+      <v-card-text class="pb-0">
+        <p class="body-2">{{ question }}</p>
+      </v-card-text>
+
+      <!-- AFC filament mapping -->
+      <start-print-dialog-afc
+        v-if="afcEnabled"
+        :file="file"
+        @tool-count="validateToolCount"
+      />
+      <!-- Spoolman fallback -->
+      <start-print-dialog-spoolman
+        v-else-if="moonrakerComponents.includes('spoolman')"
+        :file="file"
+      />
+
+      <template v-if="moonrakerComponents.includes('timelapse')">
+        <v-divider
+          v-if="!moonrakerComponents.includes('spoolman') || !afcEnabled"
+          class="mt-3 mb-2"
+        />
+        <v-card-text class="py-0">
+          <settings-row :title="$t('Dialogs.StartPrint.Timelapse')">
+            <v-switch v-model="timelapseEnabled" hide-details class="mt-0" />
+          </settings-row>
+        </v-card-text>
+        <v-divider class="mt-2 mb-0" />
+      </template>
+
+      <v-card-actions>
+        <v-spacer />
+        <v-btn text @click="closeDialog">
+          {{ $t('Dialogs.StartPrint.Cancel') }}
+        </v-btn>
+        <v-btn
+          color="primary"
+          text
+          :disabled="printerIsPrinting || !klipperReadyForGui || !validToolCount"
+          @click="startPrint(file.filename)"
+        >
+          {{ $t('Dialogs.StartPrint.Print') }}
+        </v-btn>
+      </v-card-actions>
+    </v-card>
+  </v-dialog>
+</template>
+
+<script lang="ts">
+import { Component, Mixins, Prop } from 'vue-property-decorator'
+import BaseMixin from '@/components/mixins/base'
+import SettingsRow from '@/components/settings/SettingsRow.vue'
+import StartPrintDialogAfc from '@/components/dialogs/StartPrintDialogAfc.vue'
+import { FileStateGcodefile } from '@/store/files/types'
+import { ServerSpoolmanStateSpool } from '@/store/server/spoolman/types'
+import { mdiPrinter3d } from '@mdi/js'
+import { defaultBigThumbnailBackground, thumbnailBigMin } from '@/store/variables'
+
+@Component({
+  components: { SettingsRow, StartPrintDialogAfc },
+})
+export default class StartPrintDialog extends Mixins(BaseMixin) {
+  mdiPrinter3d = mdiPrinter3d
+  validToolCount = true
+
+  @Prop({ required: true, default: false }) readonly bool!: boolean
+  @Prop({ required: true, default: '' }) readonly currentPath!: string
+  @Prop({ required: true }) file!: FileStateGcodefile
+
+  get timelapseEnabled() {
+    return this.$store.state.server.timelapse?.settings?.enabled ?? false
+  }
+  set timelapseEnabled(val: boolean) {
+    this.$socket.emit(
+      'machine.timelapse.post_settings',
+      { enabled: val },
+      { action: 'server/timelapse/initSettings' }
+    )
+  }
+
+  get afcEnabled() {
+    return 'AFC' in this.$store.state.printer
+  }
+
+  get bigThumbnailBackground() {
+    return (
+      this.$store.state.gui.uiSettings.bigThumbnailBackground ??
+      defaultBigThumbnailBackground
+    )
+  }
+  get bigThumbnailStyle() {
+    return defaultBigThumbnailBackground.toLowerCase() ===
+      this.bigThumbnailBackground.toLowerCase()
+      ? {}
+      : { backgroundColor: this.bigThumbnailBackground }
+  }
+
+  get active_spool(): ServerSpoolmanStateSpool | null {
+    return this.$store.state.server.spoolman.active_spool ?? null
+  }
+  get filamentVendor() {
+    return this.active_spool?.filament?.vendor?.name ?? 'Unknown'
+  }
+  get filamentName() {
+    return this.active_spool?.filament.name ?? 'Unknown'
+  }
+  get filament() {
+    return `${this.filamentVendor} - ${this.filamentName}`
+  }
+
+  get question() {
+    if (this.active_spool) {
+      return this.$t('Dialogs.StartPrint.DoYouWantToStartFilenameFilament', {
+        filename: this.file?.filename ?? 'unknown',
+      })
+    }
+    return this.$t('Dialogs.StartPrint.DoYouWantToStartFilename', {
+      filename: this.file?.filename ?? 'unknown',
+    })
+  }
+
+  get fileTimestamp() {
+    return typeof this.file.modified.getTime === 'function'
+      ? this.file.modified.getTime()
+      : 0
+  }
+  get thumbnails() {
+    return this.file.thumbnails ?? []
+  }
+  get bigThumbnail() {
+    return this.thumbnails.find(
+      (thumb) => thumb.width >= thumbnailBigMin
+    )
+  }
+  get currentPathWithoutSlash() {
+    return this.currentPath.startsWith('/')
+      ? this.currentPath.substring(1)
+      : this.currentPath
+  }
+  get bigThumbnailUrl() {
+    if (!this.bigThumbnail || !('relative_path' in this.bigThumbnail)) return null
+    const base = [
+      this.apiUrl,
+      'server/files/gcodes',
+      this.currentPathWithoutSlash,
+      this.bigThumbnail.relative_path,
+    ].filter(Boolean)
+    return `${base.join('/')}?timestamp=${this.fileTimestamp}`
+  }
+  get maxThumbnailWidth() {
+    return this.bigThumbnail?.width ?? 400
+  }
+
+  mounted() {
+    if (this.afcEnabled) {
+      this.$store.dispatch('server/afc/startAFCDataFetchInterval')
+    }
+  }
+
+  startPrint(filename = '') {
+    filename = (this.currentPath + '/' + filename).substring(1)
+    this.closeDialog()
+    this.$socket.emit('printer.print.start', { filename }, { action: 'switchToDashboard' })
+  }
+
+  validateToolCount(valid: boolean) {
+    this.validToolCount = valid
+  }
+
+  closeDialog() {
+    this.$emit('closeDialog')
+  }
+}
+</script>
+

--- a/src/components/dialogs/StartPrintDialogAfc.vue
+++ b/src/components/dialogs/StartPrintDialogAfc.vue
@@ -1,0 +1,25 @@
+<template>
+  <div class="afc-start-print-dialog">
+    <afc-start-print :file="file" @tool-count="$emit('tool-count', $event)" />
+  </div>
+</template>
+
+<script lang="ts">
+import { Component, Prop, Vue } from 'vue-property-decorator'
+import AfcStartPrint from '@/components/panels/Afc/AfcStartPrint.vue'
+import { FileStateGcodefile } from '@/store/files/types'
+
+@Component({
+  components: { AfcStartPrint },
+})
+export default class StartPrintDialogAfc extends Vue {
+  @Prop({ required: true }) file!: FileStateGcodefile
+}
+</script>
+
+<style scoped>
+.afc-start-print-dialog {
+  margin-top: 8px;
+}
+</style>
+

--- a/src/components/panels/Afc/AfcStartPrint.vue
+++ b/src/components/panels/Afc/AfcStartPrint.vue
@@ -1,0 +1,38 @@
+<template>
+  <div class="afc-start-print">
+    <afc-start-print-item
+      v-for="(tool, idx) in tools"
+      :key="idx"
+      :tool="tool"
+    />
+  </div>
+</template>
+
+<script lang="ts">
+import { Component, Prop, Vue } from 'vue-property-decorator'
+import AfcStartPrintItem from '@/components/panels/Afc/AfcStartPrintItem.vue'
+
+@Component({
+  components: { AfcStartPrintItem },
+})
+export default class AfcStartPrint extends Vue {
+  @Prop({ required: true }) file!: any
+
+  get tools() {
+    return this.file?.analysis?.tools ?? []
+  }
+
+  mounted() {
+    this.$emit('tool-count', this.tools.length > 0)
+  }
+}
+</script>
+
+<style scoped>
+.afc-start-print {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+}
+</style>
+

--- a/src/components/panels/Afc/AfcStartPrintItem.vue
+++ b/src/components/panels/Afc/AfcStartPrintItem.vue
@@ -1,0 +1,34 @@
+<template>
+  <div class="afc-start-print-item">
+    <span class="tool-label">Tool {{ displayIndex }}</span>
+    <span class="tool-material">{{ tool.material || 'Unknown' }}</span>
+  </div>
+</template>
+
+<script lang="ts">
+import { Component, Prop, Vue } from 'vue-property-decorator'
+
+@Component
+export default class AfcStartPrintItem extends Vue {
+  @Prop({ required: true }) tool!: any
+
+  get displayIndex() {
+    return this.tool.index ?? 0
+  }
+}
+</script>
+
+<style scoped>
+.afc-start-print-item {
+  display: flex;
+  justify-content: space-between;
+  padding: 4px 0;
+}
+.tool-label {
+  font-weight: 500;
+}
+.tool-material {
+  opacity: 0.8;
+}
+</style>
+


### PR DESCRIPTION
## Summary
- add StartPrintDialog.vue integrating AFC filament mapping with existing Spoolman and timelapse options
- introduce StartPrintDialogAfc wrapper plus AfcStartPrint and AfcStartPrintItem helpers

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68bfb5f9c764832692adac39ef239c8a