### PR TITLE
fix: guard spoolman active spool lookup

### DIFF
--- a/src/components/dialogs/StartPrintDialog.vue
+++ b/src/components/dialogs/StartPrintDialog.vue
@@ -132,7 +132,7 @@ export default class StartPrintDialog extends Mixins(BaseMixin) {
   }
 
   get active_spool(): ServerSpoolmanStateSpool | null {
-    return this.$store.state.server.spoolman.active_spool ?? null
+    return this.$store.state.server.spoolman?.active_spool ?? null
   }
   get filamentVendor() {
     return this.active_spool?.filament?.vendor?.name ?? 'Unknown'


### PR DESCRIPTION
## Summary
- avoid crash when Spoolman module is absent by guarding active spool lookup

## Testing
- `npm test` *(fails: Could not read package.json: ENOENT)*

------
https://chatgpt.com/codex/tasks/task_e_68bfbda9d9c88326b77799828be30d73